### PR TITLE
refactor: drop dependency on object assign

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,5 @@
 'use strict'
 
-var assign = require('object-assign')
-
 module.exports = u
 
 function u(type, props, value) {
@@ -15,7 +13,7 @@ function u(type, props, value) {
     props = {}
   }
 
-  node = assign({type: String(type)}, props)
+  node = Object.assign({type: String(type)}, props)
 
   if (Array.isArray(value)) {
     node.children = value

--- a/package.json
+++ b/package.json
@@ -28,9 +28,7 @@
     "types/index.d.ts"
   ],
   "types": "types/index.d.ts",
-  "dependencies": {
-    "object-assign": "^4.1.0"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@types/mdast": "^3.0.0",
     "dtslint": "^0.9.9",


### PR DESCRIPTION
Object.assign is now a native part of JavaScript
`object-assign` the package can be safely removed on Node and for most browsers (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign)

This reduces the bundled size significantly
![Screenshot_2019-10-30 unist-builder 2 0 0 ❘ BundlePhobia](https://user-images.githubusercontent.com/3107513/67921307-8c42cc00-fb64-11e9-86b7-d4c5caf65ac8.png)

